### PR TITLE
Fix space before attribute delimiter

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -149,6 +149,7 @@ module.exports = grammar({
           ),
 
           [`_attrs_delimited_${suffix}`]: $ => seq(
+            optional($._space),
             delim_open,
             repeat(seq(
               optional($._space_or_newline), alias($[`_attr_delimited_${suffix}`], $.attr)

--- a/test/corpus/attributes.txt
+++ b/test/corpus/attributes.txt
@@ -140,13 +140,13 @@ a[
         (attr_assignment)
         (attr_value)))))
 
-===============================================
-String attributes - delimited multiline variant
-===============================================
+===================================================================
+String attributes - delimited multiline with space before delimiter
+===================================================================
 
 a {
-    href="/"
-  }
+  href="/"
+}
 
 -----
 

--- a/test/corpus/attributes.txt
+++ b/test/corpus/attributes.txt
@@ -140,6 +140,25 @@ a[
         (attr_assignment)
         (attr_value)))))
 
+===============================================
+String attributes - delimited multiline variant
+===============================================
+
+a {
+    href="/"
+  }
+
+-----
+
+(source_file
+  (element
+    (tag_name)
+    (attrs
+      (attr
+        (attr_name)
+        (attr_assignment)
+        (attr_value)))))
+
 ================================
 Splat attributes - non-delimited
 ================================


### PR DESCRIPTION
First off all, thanks for your great work! I created a [Nova extension](https://github.com/calmyournerves/nova-slim-treesitter) based on your project and it seems to work great mostly. I will try to create PRs here when I find something that isn't working as expected.

Slim allows the `code_attr_delims` to have a space before the delimiter, from their docs:

```
You may use spaces around the wrappers and assignments:

h1 id = "logo" = page_logo
h2 [ id = "tagline" ] = page_tagline
```

Although it isn't explicitly stated in the docs, this also works for multiline attributes, which we are using in our codebase.

```slim
h2 [
  id=tagline
]
```

This doesn't work currently with a space before `[`.

I'm not too familiar with tree-sitter, but tried to fix this with this PR.