### PR TITLE
Add support for `:` and `/` in css class names

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -193,8 +193,9 @@ module.exports = grammar({
     _element_rest_text: $ => token(prec(-3, /[^ \t][^\n]*/)),
 
     // From css grammar https://github.com/tree-sitter/tree-sitter-css/blob/master/grammar.js
-    // Originally: /\A(#{keys}+)((?:\p{Word}|-|\/\d+|:(\w|-)+)*)/
-    css_identifier: $ => /(--|-?[a-zA-Z_])[a-zA-Z0-9-_]*/,
+    // Originally from Slim: /\A(#{keys}+)((?:\p{Word}|-|\/\d+|:(\w|-)+)*)/
+    // With added support for `:` and `/`
+    css_identifier: $ => /(--|-?[a-zA-Z_])[a-zA-Z0-9-_:\/]*/,
 
     // From doc, mostly unclear, which means which
     doctype: $ => seq(

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1086,7 +1086,7 @@
     },
     "css_identifier": {
       "type": "PATTERN",
-      "value": "(--|-?[a-zA-Z_])[a-zA-Z0-9-_]*"
+      "value": "(--|-?[a-zA-Z_])[a-zA-Z0-9-_:\\/]*"
     },
     "doctype": {
       "type": "SEQ",

--- a/src/parser.c
+++ b/src/parser.c
@@ -2808,9 +2808,10 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 210:
       ACCEPT_TOKEN(sym_css_identifier);
-      if (lookahead == '0') ADVANCE(211);
+      if (lookahead == '/' ||
+          lookahead == '0') ADVANCE(211);
       if (lookahead == '-' ||
-          ('1' <= lookahead && lookahead <= '9') ||
+          ('1' <= lookahead && lookahead <= ':') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(210);
@@ -2818,7 +2819,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
     case 211:
       ACCEPT_TOKEN(sym_css_identifier);
       if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
+          ('/' <= lookahead && lookahead <= ':') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(211);

--- a/src/parser.c
+++ b/src/parser.c
@@ -2783,7 +2783,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
     case 210:
       ACCEPT_TOKEN(sym_css_identifier);
       if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
+          ('/' <= lookahead && lookahead <= ':') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(210);

--- a/test/corpus/tags.txt
+++ b/test/corpus/tags.txt
@@ -15,6 +15,25 @@ span.menu.active
       (attr_shortcut_class
         (css_identifier)))))
 
+================================
+Tag and css classes with : and /
+================================
+
+span.hidden.lg:block.w-1/2
+
+---
+
+(source_file
+  (element
+    (tag_name)
+    (attr_shortcuts
+      (attr_shortcut_class
+        (css_identifier))
+      (attr_shortcut_class
+        (css_identifier))
+      (attr_shortcut_class
+        (css_identifier)))))
+
 ===============================
 Tag with traling space modifier
 ===============================


### PR DESCRIPTION
Slim allows colons (`:`)  and forward slashes ('/') in CSS classes. This was added to support the syntax used by TailwindCSS, e.g. `span.hidden.lg:block.w-1/2`.

This PR adds support for these characters in CSS classes.