### PR TITLE
Fix scanner.c not included in bindings

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -35,7 +35,7 @@ let package = Package(
                 ],
                 sources: [
                     "src/parser.c",
-                    // NOTE: if your language has an external scanner, add it here.
+                    "src/scanner.c",
                 ],
                 resources: [
                     .copy("queries")

--- a/binding.gyp
+++ b/binding.gyp
@@ -11,7 +11,7 @@
       "sources": [
         "bindings/node/binding.cc",
         "src/parser.c",
-        # NOTE: if your language has an external scanner, add it here.
+        "src/scanner.c",
       ],
       "conditions": [
         ["OS!='win'", {

--- a/bindings/rust/build.rs
+++ b/bindings/rust/build.rs
@@ -16,11 +16,9 @@ fn main() {
     // If your language uses an external scanner written in C,
     // then include this block of code:
 
-    /*
     let scanner_path = src_dir.join("scanner.c");
     c_config.file(&scanner_path);
     println!("cargo:rerun-if-changed={}", scanner_path.to_str().unwrap());
-    */
 
     c_config.compile("parser");
     println!("cargo:rerun-if-changed={}", parser_path.to_str().unwrap());
@@ -28,14 +26,14 @@ fn main() {
     // If your language uses an external scanner written in C++,
     // then include this block of code:
 
-    let mut cpp_config = cc::Build::new();
-    cpp_config.cpp(true);
-    cpp_config.include(&src_dir);
-    cpp_config
-        .flag_if_supported("-Wno-unused-parameter")
-        .flag_if_supported("-Wno-unused-but-set-variable");
-    let scanner_path = src_dir.join("scanner.cc");
-    cpp_config.file(&scanner_path);
-    cpp_config.compile("scanner");
-    println!("cargo:rerun-if-changed={}", scanner_path.to_str().unwrap());
+    // let mut cpp_config = cc::Build::new();
+    // cpp_config.cpp(true);
+    // cpp_config.include(&src_dir);
+    // cpp_config
+    //     .flag_if_supported("-Wno-unused-parameter")
+    //     .flag_if_supported("-Wno-unused-but-set-variable");
+    // let scanner_path = src_dir.join("scanner.cc");
+    // cpp_config.file(&scanner_path);
+    // cpp_config.compile("scanner");
+    // println!("cargo:rerun-if-changed={}", scanner_path.to_str().unwrap());
 }

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
             sources=[
                 "bindings/python/tree_sitter_slim/binding.c",
                 "src/parser.c",
-                # NOTE: if your language uses an external scanner, add it here.
+                "src/scanner.c",
             ],
             extra_compile_args=[
                 "-std=c11",


### PR DESCRIPTION
The sourcefile for the scanner `src/scanner.c` is apparently not included in the language binding setting files. This fix enables a proper binding to each language. Tested in Python. 